### PR TITLE
Add QuickNotes plugin - Create, manage, and search notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [Need](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#need) - Key-value store for important information.
 - [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.<!--lint enable double-link-->
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
+- [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) - Create, manage, and search notes directly from your launcher interface.
 
 ## Resources
 


### PR DESCRIPTION
I'd like to add my QuickNotes plugin to the Awesome PowerToys Run Plugins list.

QuickNotes is a plugin for PowerToys Run that allows users to quickly create, manage, and search notes directly from the launcher interface. Simply type 'qq' followed by your note text to save it, or use various commands to manage your notes collection.

Repository: https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes

The plugin meets all the requirements for inclusion:
- It's fully tested and documented
- It provides unique functionality for PowerToys Run users
- It follows all the packaging and distribution guidelines

Thank you for considering my submission!
