### PR TITLE
Organize plugins in alphabetical order

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,35 +45,35 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 
 ## Plugins
 
-- [GEmojiSharp](https://github.com/hlaueriksson/GEmojiSharp#gemojisharppowertoysrun) - Find and copy GitHub emoji.
-- [Everything](https://github.com/lin-ycv/EverythingPowerToys) - Find files and folders instantly with Everything.
-- [PowerTranslator](https://github.com/N0I0C0K/PowerTranslator) - Translate text with Youdao Translation.
-- [WinGet](https://github.com/bostrot/PowerToysRunPluginWinget) - Install and manage Windows packages with WinGet.
-- [Lorem](https://github.com/dxn-9/prun-lorem) - Generate lorem ipsum texts.
-- [TOTP](https://github.com/KawaiiZapic/PowertoysRunTOTP) - Copy time-based two factor verify codes.
-- [Scoop](https://github.com/Quriz/PowerToysRunScoop) - Install and manage Windows packages with Scoop.
-- [InputTyper](https://github.com/CoreyHayward/PowerToys-Run-InputTyper) - Type text as if sent from a keyboard.
-- [CurrencyConverter](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter) - Convert traditional and cryptocurrency with the latest exchange rates.
-- [EdgeFavorite](https://github.com/davidegiacometti/PowerToys-Run-EdgeFavorite) - Open Microsoft Edge favorites.
-- [GitKraken](https://github.com/davidegiacometti/PowerToys-Run-GitKraken) - Open GitKraken repositories.
-- [VisualStudio](https://github.com/davidegiacometti/PowerToys-Run-VisualStudio) - Open recent solutions in Visual Studio.
-- [ClipboardManager](https://github.com/CoreyHayward/PowerToys-Run-ClipboardManager) - Search and paste from clipboard history.
-- [GitHubRepo](https://github.com/8LWXpg/PowerToysRun-GitHubRepo) - Open GitHub repositories.
-- [ProcessKiller](https://github.com/8LWXpg/PowerToysRun-ProcessKiller) - Kill Windows processes.
-- [WebSearchShortcut](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut) - Search with predefined search engines.
-- [UnicodeInput](https://github.com/nathancartlidge/powertoys-run-unicode) - Find and copy Unicode characters with Agda-style shorthands.
-- [Timer](https://github.com/CoreyHayward/PowerToys-Run-Timer) - Set and manage timers.
-- [HexInspector](https://github.com/NaroZeol/PowerHexInspector) - Convert numbers between bases.
-- [LocalLLM](https://github.com/Darkdriller/PowerToys-Run-LocalLLm) - Query local LLM models with Ollama.
-- [JohnnyDecimal](https://github.com/seguri/PowerToys-Run-JohnnyDecimal) - Navigate through your JohnnyDecimal system.
-- [BrowserFavorite](https://github.com/Der-Penz/PowerToys-Run-BrowserFavorite) - Quickly open your Browser Bookmarks.
-- [Universal Search Suggestions](https://github.com/Fefedu973/PowerToys-Run-Universal-Search-Suggestions-Plugin/) - Adds search suggestions when typing something.<!--lint disable double-link-->
 - [Bang](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#bang) - Search websites with DuckDuckGo !Bangs.
+- [BrowserFavorite](https://github.com/Der-Penz/PowerToys-Run-BrowserFavorite) - Quickly open your Browser Bookmarks.
+- [ClipboardManager](https://github.com/CoreyHayward/PowerToys-Run-ClipboardManager) - Search and paste from clipboard history.
+- [CurrencyConverter](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter) - Convert traditional and cryptocurrency with the latest exchange rates.
 - [DenCode](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#dencode) - Encoding & Decoding.
 - [Dice](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#dice) - Roleplaying dice roller.
+- [EdgeFavorite](https://github.com/davidegiacometti/PowerToys-Run-EdgeFavorite) - Open Microsoft Edge favorites.
+- [Everything](https://github.com/lin-ycv/EverythingPowerToys) - Find files and folders instantly with Everything.
+- [GEmojiSharp](https://github.com/hlaueriksson/GEmojiSharp#gemojisharppowertoysrun) - Find and copy GitHub emoji.
+- [GitHubRepo](https://github.com/8LWXpg/PowerToysRun-GitHubRepo) - Open GitHub repositories.
+- [GitKraken](https://github.com/davidegiacometti/PowerToys-Run-GitKraken) - Open GitKraken repositories.
+- [HexInspector](https://github.com/NaroZeol/PowerHexInspector) - Convert numbers between bases.
+- [InputTyper](https://github.com/CoreyHayward/PowerToys-Run-InputTyper) - Type text as if sent from a keyboard.
+- [JohnnyDecimal](https://github.com/seguri/PowerToys-Run-JohnnyDecimal) - Navigate through your JohnnyDecimal system.
+- [LocalLLM](https://github.com/Darkdriller/PowerToys-Run-LocalLLm) - Query local LLM models with Ollama.
+- [Lorem](https://github.com/dxn-9/prun-lorem) - Generate lorem ipsum texts.
 - [Need](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#need) - Key-value store for important information.
-- [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.<!--lint enable double-link-->
+- [PowerTranslator](https://github.com/N0I0C0K/PowerTranslator) - Translate text with Youdao Translation.
+- [ProcessKiller](https://github.com/8LWXpg/PowerToysRun-ProcessKiller) - Kill Windows processes.
+- [Scoop](https://github.com/Quriz/PowerToysRunScoop) - Install and manage Windows packages with Scoop.
 - [SVGL](https://github.com/SameerJS6/powertoys-svgl) - Browse, search, and copy SVG logos via svgl.
+- [Timer](https://github.com/CoreyHayward/PowerToys-Run-Timer) - Set and manage timers.
+- [TOTP](https://github.com/KawaiiZapic/PowertoysRunTOTP) - Copy time-based two factor verify codes.
+- [Twitch](https://github.com/hlaueriksson/Community.PowerToys.Run.Plugins#twitch) - Browse, search and view streams on Twitch.
+- [UnicodeInput](https://github.com/nathancartlidge/powertoys-run-unicode) - Find and copy Unicode characters with Agda-style shorthands.
+- [Universal Search Suggestions](https://github.com/Fefedu973/PowerToys-Run-Universal-Search-Suggestions-Plugin/) - Adds search suggestions when typing something.
+- [VisualStudio](https://github.com/davidegiacometti/PowerToys-Run-VisualStudio) - Open recent solutions in Visual Studio.
+- [WebSearchShortcut](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut) - Search with predefined search engines.
+- [WinGet](https://github.com/bostrot/PowerToysRunPluginWinget) - Install and manage Windows packages with WinGet.
 
 ## Resources
 


### PR DESCRIPTION
I'd like to propose organizing the plugins list in alphabetical order.

This change makes the list more user-friendly and easier to navigate, especially as the number of plugins continues to grow. Alphabetical ordering is a common practice in awesome lists and will help users find specific plugins more quickly.

No plugins were added or removed - this is purely a reorganization of the existing content.

Thank you for considering this improvement!