### PR TITLE
Add DiskAnalyzer plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [RandomGen](https://github.com/ruslanlap/PowerToysRun-RandomGen) - Generate various types of random data.
 - [Hotkeys](https://github.com/ruslanlap/PowerToysRun-Hotkeys) - Find and copy keyboard shortcuts for various applications.
 - [TemplateRunner](https://github.com/Heck-R/PowerToys.Run.Plugin.TemplateRunner) - Use simple commands and scripts as mini plugins.
+- [DiskAnalyzer](https://github.com/thetsaw/PowerToys.Plugin) - Analyze disk space usage by folder.
 - [DiskAnalyzer](https://github.com/thetsaw/PowerToys.Plugin) - Scan folders, find the largest files, and view drive space usage with visual progress bars.
 
 ## Resources

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ PowerToys Run is a quick launcher for Windows. It is open-source and modular for
 - [RandomGen](https://github.com/ruslanlap/PowerToysRun-RandomGen) - Generate various types of random data.
 - [Hotkeys](https://github.com/ruslanlap/PowerToysRun-Hotkeys) - Find and copy keyboard shortcuts for various applications.
 - [TemplateRunner](https://github.com/Heck-R/PowerToys.Run.Plugin.TemplateRunner) - Use simple commands and scripts as mini plugins.
+- [DiskAnalyzer](https://github.com/thetsaw/PowerToys.Plugin) - Scan folders, find the largest files, and view drive space usage with visual progress bars.
 
 ## Resources
 


### PR DESCRIPTION
Added DiskAnalyzer plugin to the list of plugins in the README.

https://github.com/thetsaw/PowerToys.Plugin

DiskAnalyzer is a PowerToys Run plugin that lets you scan any folder or drive to find the largest files and folders, with visual progress bars showing disk space usage. It supports context menu actions (scan folder, open in Explorer) and works on both x64 and ARM64.

### By submitting this pull request I confirm I've read and complied with the below requirements

## Requirements for your pull request

- [x] You have read and understood the Contribution Guidelines.
- [x] This pull request has a title in the format `Add [PluginName]`.
- [x] Your entry should include a short description of the plugin.
- [x] The link text is the `Name` from plugin.json. The URL is the link to the GitHub repo.
- [x] Your entry is added at the bottom of the appropriate category.
- [x] The suggested plugin complies with the below requirements.

## Requirements for your plugin

- [x] Has been around for at least 30 days.
- [x] Ran `ptrun-lint` and fixed reported issues.
- [x] Scanned with VirusTotal — no security vendors flagged the files.
- [x] It's the result of hard work and the best I could possibly produce.
- [x] Not a clone of an existing plugin.
- [x] Is awesome.